### PR TITLE
Integrate with `turbo:load`

### DIFF
--- a/app/assets/javascripts/belongs_to_search.js
+++ b/app/assets/javascripts/belongs_to_search.js
@@ -1,5 +1,5 @@
 // belongs_to form
-$(function() {
+function install() {
   $(".field-unit--belongs-to-search select").each(function initializeSelectize(index, element) {
     var $element = $(element);
     $element.selectize({
@@ -25,4 +25,10 @@ $(function() {
       },
     });
   });
-});
+};
+
+if (window.Turbo) {
+  addEventListener("turbo:load", install)
+} else {
+  $(install)
+}


### PR DESCRIPTION
Administrate `1.0.0` is poised to integrate with Turbo and Stimulus. That means that plugins that utilize client-side JavaScript cannot depend on `DOMContentLoaded` events in the same way as pre-1.0.0.

First, check for `window.Turbo`. If that exists, install the listener for [`turbo:load`][] events.

If not, fall back to using `jQuery` to attach [`DOMContentLoaded`][] events.

[`turbo:load`]: https://turbo.hotwired.dev/reference/events#turbo%3Aload
[`DOMContentLoaded`]: https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event